### PR TITLE
Update to Correct GA Tags

### DIFF
--- a/AncientLives/index.html
+++ b/AncientLives/index.html
@@ -98,7 +98,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-27','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/AsteroidZoo/index.html
+++ b/AsteroidZoo/index.html
@@ -98,7 +98,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-56','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/BatDetective/index.html
+++ b/BatDetective/index.html
@@ -75,7 +75,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-32','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/CellSlider/index.html
+++ b/CellSlider/index.html
@@ -98,7 +98,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-34','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/ChimpAndSee/index.html
+++ b/ChimpAndSee/index.html
@@ -67,7 +67,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-34','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/CondorWatch/index.html
+++ b/CondorWatch/index.html
@@ -96,7 +96,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-54','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/CycloneCenter/index.html
+++ b/CycloneCenter/index.html
@@ -65,7 +65,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-33','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/DiskDetective/index.html
+++ b/DiskDetective/index.html
@@ -60,8 +60,8 @@
                 Disk Detective to find thousands of these disks, including new kinds
                 of disks that had never been seen before, like the "Peter Pan Disk"
                 illustrated here (credit: Jonathan Holden). We're working on a new
-                version of Disk Detective that will be even more powerful. 
-                Send an email to 
+                version of Disk Detective that will be even more powerful.
+                Send an email to
                 <a href="mailto:diskdetectives@gmail.com">
                   diskdetectives@gmail.com
                 </a>
@@ -90,7 +90,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-50','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/HiggsHunters/index.html
+++ b/HiggsHunters/index.html
@@ -93,7 +93,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-60','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/Microplants/index.html
+++ b/Microplants/index.html
@@ -66,13 +66,5 @@
 
         <script src="js/vendor/bootstrap.min.js"></script>
         <script src="js/main.js"></script>
-        <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='//www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
-        </script>
     </body>
 </html>

--- a/MoonZoo/index.html
+++ b/MoonZoo/index.html
@@ -97,7 +97,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-20','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/OldWeatherWhaling/index.html
+++ b/OldWeatherWhaling/index.html
@@ -59,7 +59,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-17','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/OperationWarDiary/index.html
+++ b/OperationWarDiary/index.html
@@ -64,7 +64,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-51','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/OrchidObservers/index.html
+++ b/OrchidObservers/index.html
@@ -66,13 +66,5 @@
         <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
 
         <script src="js/vendor/bootstrap.min.js"></script>
-        <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='//www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
-        </script>
     </body>
 </html>

--- a/PlanetFour/index.html
+++ b/PlanetFour/index.html
@@ -188,7 +188,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-41','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/PlanetHunters/index.html
+++ b/PlanetHunters/index.html
@@ -89,7 +89,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-25','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/RadioGalaxyZoo/index.html
+++ b/RadioGalaxyZoo/index.html
@@ -73,7 +73,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-49','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/ScienceGossip/index.html
+++ b/ScienceGossip/index.html
@@ -71,7 +71,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-17','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/SeafloorExplorer/index.html
+++ b/SeafloorExplorer/index.html
@@ -70,7 +70,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-30','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/WormWatch/index.html
+++ b/WormWatch/index.html
@@ -64,7 +64,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-44','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/setilive/index.html
+++ b/setilive/index.html
@@ -74,7 +74,7 @@
             e=o.createElement(i);r=o.getElementsByTagName(i)[0];
             e.src='//www.google-analytics.com/analytics.js';
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
+            ga('create','UA-1224199-29','auto');ga('send','pageview');
         </script>
     </body>
 </html>

--- a/solarstormwatch/index.html
+++ b/solarstormwatch/index.html
@@ -93,13 +93,5 @@
 
         <script src="js/vendor/bootstrap.min.js"></script>
         <script src="js/main.js"></script>
-        <script>
-            (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-            function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-            e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-            e.src='//www.google-analytics.com/analytics.js';
-            r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-            ga('create','UA-1224199-28','auto');ga('send','pageview');
-        </script>
     </body>
 </html>


### PR DESCRIPTION
Closes #46

More info on the issue. Most projects erroneously use the WhaleFM GA tag. If you check the Google Analytics dash, you'll see a hit under WhaleFM when visiting a site like ancientlives.org

This PR adds the correct GA ids to each project and removes GA use in projects without a designated GA id.