### PR TITLE
Replace Planet Four Header Links to Project Builder

### DIFF
--- a/PlanetFour/index.html
+++ b/PlanetFour/index.html
@@ -29,9 +29,9 @@
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
       <div class="container">
         <div class="navbar-header">
-          <a class="navbar-brand headline" href="#/index">Archived Zooniverse Project: Planet Four</a>
+          <a class="navbar-brand headline" href="https://www.zooniverse.org/projects/mschwamb/planet-four">Planet Four</a>
           <a class="navbar-brand headline" href="#/authors">Authors</a>
-          <a class="navbar-brand headline" href="#/results">Results</a>
+          <a class="navbar-brand headline" href="https://www.zooniverse.org/projects/mschwamb/planet-four/about/results">Results</a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
With the upcoming relaunch of Planet Four on the project builder, the archived Planet Four page will change a bit. We'd like to keep the /authors address live, but the header redirects should instead point to the project builder project. 

On the screenshot below, Planet Four will redirect to the [project builder version](https://www.zooniverse.org/projects/mschwamb/planet-four) while results will point to the [results section](https://www.zooniverse.org/projects/mschwamb/planet-four/about/results) under the about tab of that project.
<img width="463" alt="Screen Shot 2020-03-20 at 10 07 01 AM" src="https://user-images.githubusercontent.com/14099077/77176818-9bce9d00-6a92-11ea-9cc9-b5d4d5c801a7.png">